### PR TITLE
closes #19, removed dependency on heketi

### DIFF
--- a/tests/assert.go
+++ b/tests/assert.go
@@ -1,4 +1,4 @@
-// From https://github.com/heketi/heketi
+// Package tests borrows Assert() from https://github.com/heketi/heketi
 package tests
 
 import (
@@ -6,14 +6,14 @@ import (
 	"testing"
 )
 
-// Simple assert call for unit and functional tests
+// Assert provides a simple assert call for unit and functional tests
 func Assert(t *testing.T, b bool) {
 	if !b {
 		pc, file, line, _ := runtime.Caller(1)
-		caller_func_info := runtime.FuncForPC(pc)
+		callFuncInfo := runtime.FuncForPC(pc)
 
 		t.Errorf("\n\rASSERT:\tfunc (%s) 0x%x\n\r\tFile %s:%d",
-			caller_func_info.Name(),
+			callFuncInfo.Name(),
 			pc,
 			file,
 			line)

--- a/tests/assert.go
+++ b/tests/assert.go
@@ -1,0 +1,22 @@
+// From https://github.com/heketi/heketi
+package tests
+
+import (
+	"runtime"
+	"testing"
+)
+
+// Simple assert call for unit and functional tests
+func Assert(t *testing.T, b bool) {
+	if !b {
+		pc, file, line, _ := runtime.Caller(1)
+		caller_func_info := runtime.FuncForPC(pc)
+
+		t.Errorf("\n\rASSERT:\tfunc (%s) 0x%x\n\r\tFile %s:%d",
+			caller_func_info.Name(),
+			pc,
+			file,
+			line)
+		t.FailNow()
+	}
+}

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -3,8 +3,7 @@ package volume
 import (
 	"testing"
 
-	"github.com/heketi/heketi/tests"
-	"github.com/heketi/heketi/utils"
+	"github.com/kshlm/glusterd2/tests"
 )
 
 func TestNewVolumeEntry(t *testing.T) {
@@ -82,12 +81,23 @@ func TestNewVolumeEntryFromRequestRedundancy(t *testing.T) {
 	tests.Assert(t, v.RedundancyCount == 2)
 }
 
+func find(haystack []string, needle string) bool {
+
+	for _, hay := range haystack {
+		if hay == needle {
+			return true
+		}
+	}
+
+	return false
+}
+
 func TestNewVolumeEntryFromRequestBricks(t *testing.T) {
 
 	req := VolCreateRequest{}
 	req.Bricks = []string{"abc", "def"}
 
 	v := NewVolumeEntry(req)
-	tests.Assert(t, utils.SortedStringHas(v.Bricks, "abc"))
-	tests.Assert(t, utils.SortedStringHas(v.Bricks, "def"))
+	tests.Assert(t, find(v.Bricks, "abc"))
+	tests.Assert(t, find(v.Bricks, "def"))
 }

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -98,6 +98,7 @@ func TestNewVolumeEntryFromRequestBricks(t *testing.T) {
 	req.Bricks = []string{"abc", "def"}
 
 	v := NewVolumeEntry(req)
-	tests.Assert(t, find(v.Bricks, "abc"))
-	tests.Assert(t, find(v.Bricks, "def"))
+	for _, brick := range req.Bricks {
+		tests.Assert(t, find(v.Bricks, brick))
+	}
 }


### PR DESCRIPTION
Removed the dependency on github.com/ heketi/heketi just for the
Assert() function. 'Borrowed' the implementation from
github.com/heketi/heketi pkg with attribution placed in tests/assert.go

Signed-off-by: Krishnan Parthasarathi <kparthas@redhat.com>